### PR TITLE
Fix AI history fetch

### DIFF
--- a/ai-website.php
+++ b/ai-website.php
@@ -1253,10 +1253,11 @@ function voicero_admin_enqueue_assets($hook_suffix) {
         'voicero-admin-js',
         'voiceroAdminConfig',
         [
-            'ajaxUrl' => admin_url('admin-ajax.php'),
-            'nonce'   => wp_create_nonce('voicero_ajax_nonce'),
+            'ajaxUrl'   => admin_url('admin-ajax.php'),
+            'nonce'     => wp_create_nonce('voicero_ajax_nonce'),
             'accessKey' => $access_key,
-            'apiUrl' => defined('VOICERO_API_URL') ? VOICERO_API_URL : 'http://localhost:3000/api'
+            'apiUrl'    => defined('VOICERO_API_URL') ? VOICERO_API_URL : 'http://localhost:3000/api',
+            'websiteId' => get_option('voicero_website_id', '')
         ]
     );
     

--- a/assets/js/admin/voicero-ai-overview.js
+++ b/assets/js/admin/voicero-ai-overview.js
@@ -53,6 +53,9 @@
             nonce: $("#voicero_nonce").val(),
           };
 
+    // Website ID can be included in the global config
+    const websiteId = config.websiteId || $("#voicero_website_id").val();
+
     // Send AJAX request to get AI history
     $.ajax({
       url: config.ajaxUrl,
@@ -60,6 +63,7 @@
       data: {
         action: "voicero_get_ai_history",
         nonce: config.nonce,
+        websiteId: websiteId,
       },
       success: function (response) {
         hideLoadingIndicator();

--- a/includes/api.php
+++ b/includes/api.php
@@ -1910,8 +1910,10 @@ function voicero_get_ai_history_ajax() {
         return;
     }
 
-    // 4) Get the website ID
-    $website_id = get_option('voicero_website_id', '');
+    // 4) Get the website ID (allow override via request)
+    $website_id = isset($_REQUEST['websiteId'])
+        ? sanitize_text_field(wp_unslash($_REQUEST['websiteId']))
+        : get_option('voicero_website_id', '');
     error_log('AI History - Website ID from option: ' . $website_id);
     
     if (empty($website_id)) {
@@ -1942,7 +1944,9 @@ function voicero_get_ai_history_ajax() {
     error_log('AI History request data: ' . json_encode($request_data));
 
     // 7) Make the API request
-    $endpoint = 'http://localhost:3000/api/aiHistory';
+    // Allow the API base URL to be configured via constant
+    $api_base = defined('VOICERO_API_URL') ? VOICERO_API_URL : 'http://localhost:3000/api';
+    $endpoint  = trailingslashit($api_base) . 'aiHistory';
     
     try {
         $response = wp_remote_post($endpoint, [

--- a/includes/page-ai-overview.php
+++ b/includes/page-ai-overview.php
@@ -106,7 +106,9 @@ function voicero_render_ai_overview_page() {
             // Log the request data for debugging
             error_log('AI Overview page request data: ' . json_encode($request_data));
             
-            $endpoint = 'http://localhost:3000/api/aiHistory';
+            // Use the configured API base URL for flexibility
+            $api_base = defined('VOICERO_API_URL') ? VOICERO_API_URL : 'http://localhost:3000/api';
+            $endpoint  = trailingslashit($api_base) . 'aiHistory';
             $response = wp_remote_post($endpoint, [
                 'headers' => [
                     'Authorization' => 'Bearer ' . $access_key,
@@ -212,6 +214,8 @@ function voicero_render_ai_overview_page() {
         
         <!-- Add hidden nonce field for AJAX -->
         <input type="hidden" id="voicero_nonce" value="<?php echo esc_attr(wp_create_nonce('voicero_ajax_nonce')); ?>" />
+        <!-- Expose website ID for JavaScript -->
+        <input type="hidden" id="voicero_website_id" value="<?php echo esc_attr($website_id); ?>" />
         
         <div id="voicero-overview-message"></div>     
         


### PR DESCRIPTION
## Summary
- make AI history endpoint use configurable base URL
- pass website ID from JS to PHP via config and hidden input
- allow API handler to accept websiteId from request

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842354c006c832fbd02d4dbc7c4cf02